### PR TITLE
Update to UUIDs

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="lib/bukkit-1.4.6-R0.1.jar"/>
+	<classpathentry kind="lib" path="D:/minecraft server/plugins dev/spigot-1.7.9-R0.1-SNAPSHOT.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-	<classpathentry kind="lib" path="D:/minecraft server/plugins dev/spigot-1.7.9-R0.1-SNAPSHOT.jar"/>
+	<classpathentry kind="lib" path="D:/minecraft server/plugins dev/craftbukkit-1.7.9-R0.1-20140424.033947-16.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/config.yml
+++ b/config.yml
@@ -4,3 +4,4 @@ ban-votes-needed: 2
 require-member-online: false
 require-op-online: false
 open-when-op-online: false
+broadcast-failed-logins: true

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
 name: Invitation Only
-author: DeltaWhy
+author: DeltaWhy, Phoenix616
 website: https://github.com/DeltaWhy/bukkit-invitation-only
 main: com.github.deltawhy.invitationonly.InvitationOnly
-version: 0.1.0
+version: 0.1.1
 permissions:
   invitationonly.approve:
     description: Approve players for full membership.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: Invitation Only
-author: DeltaWhy, Phoenix616
+authors: [DeltaWhy, Phoenix616]
 website: https://github.com/DeltaWhy/bukkit-invitation-only
 main: com.github.deltawhy.invitationonly.InvitationOnly
 version: 0.1.2

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: Invitation Only
 author: DeltaWhy, Phoenix616
 website: https://github.com/DeltaWhy/bukkit-invitation-only
 main: com.github.deltawhy.invitationonly.InvitationOnly
-version: 0.1.1
+version: 0.1.2
 permissions:
   invitationonly.approve:
     description: Approve players for full membership.

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: Invitation Only
+name: InvitationOnly
 authors: [DeltaWhy, Phoenix616]
 website: https://github.com/DeltaWhy/bukkit-invitation-only
 main: com.github.deltawhy.invitationonly.InvitationOnly

--- a/src/com/github/deltawhy/invitationonly/ConfigAccessor.java
+++ b/src/com/github/deltawhy/invitationonly/ConfigAccessor.java
@@ -42,8 +42,6 @@ public class ConfigAccessor {
     public ConfigAccessor(JavaPlugin plugin, String fileName) {
         if (plugin == null)
             throw new IllegalArgumentException("plugin cannot be null");
-        if (!plugin.isInitialized())
-            throw new IllegalArgumentException("plugin must be initiaized");
         this.plugin = plugin;
         this.fileName = fileName;
     }

--- a/src/com/github/deltawhy/invitationonly/ConfigAccessor.java
+++ b/src/com/github/deltawhy/invitationonly/ConfigAccessor.java
@@ -88,4 +88,11 @@ public class ConfigAccessor {
         }
     }
 
+	public File getFile() {
+		File dataFolder = plugin.getDataFolder();
+        if (dataFolder == null)
+            throw new IllegalStateException();
+        return new File(dataFolder, fileName);
+	}
+
 }

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -317,4 +317,20 @@ public class InvitationOnly extends JavaPlugin {
 			userConfig.getConfig().set("members."+userid.toString()+".name", username);
 		}		
 	}
+
+	//Check if we have to kick invited players because all OPs/Members are gone.
+	public void checkPlayers() {
+		if (getConfig().getBoolean("require-op-online", false) && !isOpOnline()) {
+			getLogger().info("There is no OP online anymore. Searching for players who are only invited.");
+			for (Player p : getServer().getOnlinePlayers()) 
+				if (isInvited(p.getUniqueId()) && !p.isOp()) 
+					p.kickPlayer(ChatColor.YELLOW + "You were kicked because invited players can't play on this server without an OP online!");
+		} else if (getConfig().getBoolean("require-member-online", false) && !isMemberOnline()) {
+			getLogger().info("There is no member online anymore. Searching for players who are only invited.");
+			for (Player p : getServer().getOnlinePlayers()) 
+				if (isInvited(p.getUniqueId()) && !p.isOp()) 
+					p.kickPlayer(ChatColor.YELLOW + "You were kicked because invited players can't play on this server without an member online!");
+		}
+		
+	}
 }

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -172,7 +172,7 @@ public class InvitationOnly extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		saveDefaultConfig();		
+		saveDefaultConfig();
 		userConfig = new ConfigAccessor(this, "users.yml");
 		userConfig.reloadConfig();
 		File userConfigFile =  userConfig.getFile();
@@ -183,12 +183,12 @@ public class InvitationOnly extends JavaPlugin {
 		    if(whitelist.isEmpty()) this.getLogger().info("The whitelist seems to be empty! Not adding any members.");
 		    else {
 		    	for(OfflinePlayer player : whitelist) {
-			    	UUID userid = player.getUniqueId();
+		    		UUID userid = player.getUniqueId();
 					if (player != null && !isMember(userid)) {
 						promoteToMember(userid);
 						this.getLogger().info("Added " + player.getName() + ".");
 					}
-			    }
+		    	}
 			this.getLogger().info("Finished converting the whitelist to the users.yml! " + whitelist.size() + " new members added to the users.yml!");
 		    }		    	
 		}

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -105,6 +105,7 @@ public class InvitationOnly extends JavaPlugin {
 			if (args.length != 1) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
 			promoteToMember(userid);
+			getServer().getOfflinePlayer(userid).setWhitelisted(true);
 			return true;
 
 		//Unapprove command handling		
@@ -116,6 +117,7 @@ public class InvitationOnly extends JavaPlugin {
 				return true;
 			}
 			removeFromMembers(userid);
+			getServer().getOfflinePlayer(userid).setWhitelisted(false);
 			return true;
 			
 		//Voteapprove command handling			
@@ -260,6 +262,7 @@ public class InvitationOnly extends JavaPlugin {
 	public void removeFromMembers(UUID userid) {
 		userConfig.getConfig().set("invited."+userid.toString(), null);
 		userConfig.getConfig().set("members."+userid.toString(), null);
+		getServer().getOfflinePlayer(userid).setWhitelisted(false);
 		userConfig.saveConfig();
 		if (getServer().getOfflinePlayer(userid).isOnline() && (!getConfig().getBoolean("open-when-op-online") || !isOpOnline())) {
 			getServer().getPlayer(userid).kickPlayer(ChatColor.GOLD + "You are no longer a member!");
@@ -275,6 +278,7 @@ public class InvitationOnly extends JavaPlugin {
 		if (votesReceived >= votesNeeded) {
 			getServer().broadcastMessage(ChatColor.YELLOW + "The tribe has spoken!");
 			promoteToMember(userid);
+			getServer().getOfflinePlayer(userid).setWhitelisted(true);
 		} else {
 			getServer().broadcastMessage(ChatColor.YELLOW + getServer().getPlayer(voterid).getName()+ " voted to make " + getServer().getOfflinePlayer(userid).getName()
 					+ " a member. " + (votesNeeded - votesReceived) + " more votes needed.");
@@ -292,6 +296,7 @@ public class InvitationOnly extends JavaPlugin {
 		OfflinePlayer player = getServer().getOfflinePlayer(userid);
 		if (votesReceived >= votesNeeded) {
 			player.setBanned(true); //TODO: Change to non-deprecated BanList.addBan method when it uses UUIDs instead of usernames...
+			player.setWhitelisted(false);
 			if (player.isOnline()) getServer().getPlayer(userid).kickPlayer(ChatColor.GOLD + "You have been banned!");
 			getServer().broadcastMessage(ChatColor.YELLOW + "The tribe has spoken!");
 			getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " has been banned and cannot be re-invited.");;

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -1,5 +1,6 @@
 package com.github.deltawhy.invitationonly;
 
+import java.io.File;
 import java.util.List;
 import java.util.UUID;
 
@@ -167,7 +168,6 @@ public class InvitationOnly extends JavaPlugin {
 	public void onEnable() {
 		saveDefaultConfig();		
 		userConfig = new ConfigAccessor(this, "users.yml");
-		
 		userConfig.reloadConfig();
 		playerListener = new PlayerListener(this);
 		getServer().getPluginManager().registerEvents(playerListener, this);
@@ -207,7 +207,9 @@ public class InvitationOnly extends JavaPlugin {
 	
 	//Won't check quotas here!
 	public void invite(UUID userid, UUID uuid) {
+		String username = getServer().getOfflinePlayer(userid).getName();
 		userConfig.getConfig().createSection("invited."+userid.toString()).set("invited-by", uuid.toString());
+		userConfig.getConfig().set("invited."+userid.toString()+".name", username);
 		userConfig.saveConfig();
 		String inviter = (uuid.toString().equals("00000000-0000-0000-0000-000000000000")) ? "An admin" : getServer().getPlayer(uuid).getName() ;
 		getServer().broadcastMessage(ChatColor.YELLOW + inviter + " invited " + getServer().getOfflinePlayer(userid).getName() + " to the server!");
@@ -224,10 +226,12 @@ public class InvitationOnly extends JavaPlugin {
 	}
 	
 	public void promoteToMember(UUID userid) {
+		String username = getServer().getOfflinePlayer(userid).getName();
 		userConfig.getConfig().set("invited."+userid.toString(), null);
 		userConfig.getConfig().set("members."+userid.toString()+".invites-left", getConfig().getInt("invite-quota", 0));
+		userConfig.getConfig().set("members."+userid.toString()+".name", username);
 		userConfig.saveConfig();
-		getServer().broadcastMessage(ChatColor.YELLOW + getServer().getOfflinePlayer(userid).getName() + " is now a member! Congratulations!");
+		getServer().broadcastMessage(ChatColor.YELLOW + username + " is now a member! Congratulations!");
 	}
 	
 	public void removeFromMembers(UUID userid) {
@@ -274,5 +278,18 @@ public class InvitationOnly extends JavaPlugin {
 		}
 		userConfig.getConfig().set("invited."+userid.toString()+".ban-votes", banVotes);
 		userConfig.saveConfig();
+	}
+
+	//Function to update the name of a player to save the last known name and make the users.yml more readable for humans
+	public void updateConfigName(UUID userid, String username) {
+		if (isInvited(userid)) {
+			userConfig.getConfig().set("invited."+userid.toString()+".name", username);
+			
+		}
+		if (isMember(userid)) {
+			userConfig.getConfig().set("members."+userid.toString()+".name", username);
+		}
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -1,6 +1,7 @@
 package com.github.deltawhy.invitationonly;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -20,63 +21,64 @@ public class InvitationOnly extends JavaPlugin {
 		
 		if (command.getName().equalsIgnoreCase("invite")) {
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			String senderName = (player == null ? "$CONSOLE$" : player.getName());
-			if (player != null && !isMember(senderName)) {
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			if (player != null && !isMember(player.getUniqueId())) {
 				player.sendMessage(ChatColor.RED + "You don't have permission to invite people.");
 				return true;
 			}
-			if (isMember(username)) {
-				sender.sendMessage(ChatColor.RED + username + " is already a member!");
+			if (isMember(userid)) {
+				sender.sendMessage(ChatColor.RED + getServer().getOfflinePlayer(userid).getName() + " is already a member!");
 				return true;
 			}
-			if (isInvited(username)) {
-				sender.sendMessage(ChatColor.RED + username + " is already invited!");
+			if (isInvited(userid)) {
+				sender.sendMessage(ChatColor.RED + getServer().getOfflinePlayer(userid).getName() + " is already invited!");
 				return true;
 			}
 			if (player != null && !player.hasPermission("invitationonly.invite.unlimited")) {
-				int playerQuota = userConfig.getConfig().getInt("members."+senderName.toLowerCase()+".invites-left", 0);
+				int playerQuota = userConfig.getConfig().getInt("members."+player.getUniqueId().toString()+".invites-left", 0);
 				if (playerQuota == 0) {
 					player.sendMessage(ChatColor.RED + "You don't have any invites left!");
 					return true;
 				} else if (playerQuota > 0) {
 					playerQuota--;
-					userConfig.getConfig().set("members."+senderName.toLowerCase()+".invites-left", playerQuota);
+					userConfig.getConfig().set("members."+player.getUniqueId().toString()+".invites-left", playerQuota);
+					player.sendMessage(ChatColor.GREEN + "You have " + playerQuota + " invites left!");
 				}
 			}
-			invite(username, senderName);
+			invite(userid, player.getUniqueId());
 			return true;
 		} else if (command.getName().equalsIgnoreCase("uninvite")) {
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			String senderName = (player == null ? "$CONSOLE$" : player.getName());
-			if (!senderName.equalsIgnoreCase(whoInvited(username))) {
-				sender.sendMessage(ChatColor.RED + "You didn't invite " + username + "!");
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			// String senderName = (player == null ? "$CONSOLE$" : player.getName()); TODO
+			if (!player.getUniqueId().equals(whoInvited(userid))) {
+				sender.sendMessage(ChatColor.RED + "You didn't invite " + getServer().getOfflinePlayer(userid).getName() + "!");
 				return true;
 			}
 			if (player != null && !player.hasPermission("invitationonly.invite.unlimited")) {
-				int playerQuota = userConfig.getConfig().getInt("members."+senderName.toLowerCase()+".invites-left", -1);
+				int playerQuota = userConfig.getConfig().getInt("members."+player.getUniqueId().toString()+".invites-left", -1);
 				if (playerQuota >= 0) {
 					playerQuota++;
-					userConfig.getConfig().set("members."+senderName.toLowerCase()+".invites-left", playerQuota);
+					userConfig.getConfig().set("members."+player.getUniqueId().toString()+".invites-left", playerQuota);
 				}
 			}
-			uninvite(username);
+			uninvite(userid);
 			return true;
 		} else if (command.getName().equalsIgnoreCase("invitequota")) {
 			if (player == null && args.length == 0) return false;
-			String username = (args.length > 0) ? getServer().getOfflinePlayer(args[0]).getName() : player.getName();
-			if (!isMember(username)) {
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			String username = getServer().getOfflinePlayer(userid).getName();
+			if (!isMember(userid)) {
 				sender.sendMessage(ChatColor.RED + username + " is not a member!");
 				return true;
 			}
 			if (args.length < 2) {
-				int playerQuota = userConfig.getConfig().getInt("members."+username.toLowerCase()+".invites-left", 0);
+				int playerQuota = userConfig.getConfig().getInt("members."+userid.toString()+".invites-left", 0);
 				sender.sendMessage(ChatColor.GREEN + username + " has " + playerQuota + " invites left.");
 			} else if (args.length == 2) {
 				try {
 					int quota = Integer.parseInt(args[1]);
-					userConfig.getConfig().set("members."+username.toLowerCase()+".invites-left", quota);
+					userConfig.getConfig().set("members."+userid.toString()+".invites-left", quota);
 					userConfig.saveConfig();
 				} catch (NumberFormatException e) {
 					return false;
@@ -85,59 +87,61 @@ public class InvitationOnly extends JavaPlugin {
 			return true;
 		} else if (command.getName().equalsIgnoreCase("approveinvite")) {
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			promoteToMember(username);
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			promoteToMember(userid);
 			return true;
 		} else if (command.getName().equalsIgnoreCase("unapprove")) {
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			if (!isMember(username)) {
-				sender.sendMessage(ChatColor.RED + username + " is not a member!");
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			if (!isMember(userid)) {
+				sender.sendMessage(ChatColor.RED + getServer().getOfflinePlayer(userid).getName() + " is not a member!");
 				return true;
 			}
-			removeFromMembers(username);
+			removeFromMembers(userid);
 			return true;
 		} else if (command.getName().equalsIgnoreCase("voteapprove")) {
 			if (player == null) {
 				sender.sendMessage("This command can not be used from the console.");
 				return true;
 			}
-			if (player != null && !isMember(player.getName())) {
+			if (player != null && !isMember(player.getUniqueId())) {
 				player.sendMessage(ChatColor.RED + "Only members can vote.");
 				return true;
 			}
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			if (isMember(username)) {
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			String username = getServer().getOfflinePlayer(userid).getName();
+			if (isMember(userid)) {
 				sender.sendMessage(ChatColor.RED + username + " is already a member!");
 				return true;
 			}
-			if (!isInvited(username)) {
+			if (!isInvited(userid)) {
 				sender.sendMessage(ChatColor.RED + username + " hasn't been invited!");
 				return true;
 			}
-			voteApprove(username, player.getName());
+			voteApprove(userid, player.getUniqueId());
 			return true;
 		} else if (command.getName().equalsIgnoreCase("voteban")) {
 			if (player == null) {
 				sender.sendMessage("This command can not be used from the console.");
 				return true;
 			}
-			if (player != null && !isMember(player.getName())) {
+			if (player != null && !isMember(player.getUniqueId())) {
 				player.sendMessage(ChatColor.RED + "Only members can vote.");
 				return true;
 			}
 			if (args.length != 1) return false;
-			String username = getServer().getOfflinePlayer(args[0]).getName();
-			if (isMember(username)) {
+			UUID userid = getOfflinePlayerUUID(args[0]);
+			String username = getServer().getOfflinePlayer(userid).getName();
+			if (isMember(userid)) {
 				sender.sendMessage(ChatColor.RED + username + " is a member!");
 				return true;
 			}
-			if (!isInvited(username)) {
+			if (!isInvited(userid)) {
 				sender.sendMessage(ChatColor.RED + username + " hasn't been invited!");
 				return true;
 			}
-			voteBan(username, player.getName());
+			voteBan(userid, player.getUniqueId());
 			return true;
 		} else {
 			return false;
@@ -153,21 +157,26 @@ public class InvitationOnly extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(playerListener, this);
 	}
 	
-	public boolean isMember(String username) {
-		return userConfig.getConfig().contains("members."+username.toLowerCase());
+	@SuppressWarnings("deprecation")
+	public UUID getOfflinePlayerUUID(String username) {
+		return getServer().getOfflinePlayer(username).getUniqueId();
 	}
 	
-	public boolean isInvited(String username) {
-		return userConfig.getConfig().contains("invited."+username.toLowerCase());
+	public boolean isMember(UUID userid) {
+		return userConfig.getConfig().contains("members."+userid.toString());
 	}
 	
-	public String whoInvited(String username) {
-		return userConfig.getConfig().getString("invited."+username.toLowerCase()+".invited-by", "");
+	public boolean isInvited(UUID userid) {
+		return userConfig.getConfig().contains("invited."+userid.toString());
+	}
+	
+	public UUID whoInvited(UUID userid) {
+		return UUID.fromString(userConfig.getConfig().getString("invited."+userid.toString()+".invited-by", ""));
 	}
 	
 	public boolean isMemberOnline() {
 		for (Player p : getServer().getOnlinePlayers()) {
-			if (isMember(p.getName())) return true;
+			if (isMember(p.getUniqueId())) return true;
 		}
 		return false;
 	}
@@ -180,72 +189,73 @@ public class InvitationOnly extends JavaPlugin {
 	}
 	
 	//Won't check quotas here!
-	public void invite(String username, String whoInvited) {
-		userConfig.getConfig().createSection("invited."+username.toLowerCase()).set("invited-by", whoInvited.toLowerCase());
+	public void invite(UUID userid, UUID uuid) {
+		userConfig.getConfig().createSection("invited."+userid.toString()).set("invited-by", uuid.toString());
 		userConfig.saveConfig();
-		if (whoInvited.equals("$CONSOLE$")) whoInvited = "An admin";
-		getServer().broadcastMessage(ChatColor.YELLOW + whoInvited + " invited " + username + " to the server!");
+		//if (uuid.equals("$CONSOLE$")) uuid = "An admin";
+		getServer().broadcastMessage(ChatColor.YELLOW + getServer().getPlayer(uuid).getName() + " invited " + getServer().getOfflinePlayer(userid).getName() + " to the server!");
 	}
 	
 	//Won't check who invited!
-	public void uninvite(String username) {
-		userConfig.getConfig().set("invited."+username.toLowerCase(), null);
+	public void uninvite(UUID userid) {
+		userConfig.getConfig().set("invited."+userid.toString(), null);
 		userConfig.saveConfig();
-		if (getServer().getOfflinePlayer(username).isOnline() && !isMember(username) && (!getConfig().getBoolean("open-when-op-online", false) || !isOpOnline())) {
-			getServer().getPlayerExact(username).kickPlayer("You were un-invited!");
+		if (getServer().getOfflinePlayer(userid).isOnline() && !isMember(userid) && (!getConfig().getBoolean("open-when-op-online", false) || !isOpOnline())) {
+			getServer().getPlayer(userid).kickPlayer("You were un-invited!");
 		}
-		getServer().broadcastMessage(ChatColor.YELLOW + username + " was un-invited. You may re-invite them.");
+		getServer().broadcastMessage(ChatColor.YELLOW + getServer().getOfflinePlayer(userid).getName() + " was un-invited. You may re-invite them.");
 	}
 	
-	public void promoteToMember(String username) {
-		userConfig.getConfig().set("invited."+username.toLowerCase(), null);
-		userConfig.getConfig().set("members."+username.toLowerCase()+".invites-left", getConfig().getInt("invite-quota", 0));
+	public void promoteToMember(UUID userid) {
+		userConfig.getConfig().set("invited."+userid.toString(), null);
+		userConfig.getConfig().set("members."+userid.toString()+".invites-left", getConfig().getInt("invite-quota", 0));
 		userConfig.saveConfig();
-		getServer().broadcastMessage(ChatColor.YELLOW + username + " is now a member! Congratulations!");
+		getServer().broadcastMessage(ChatColor.YELLOW + getServer().getOfflinePlayer(userid).getName() + " is now a member! Congratulations!");
 	}
 	
-	public void removeFromMembers(String username) {
-		userConfig.getConfig().set("invited."+username.toLowerCase(), null);
-		userConfig.getConfig().set("members."+username.toLowerCase(), null);
+	public void removeFromMembers(UUID userid) {
+		userConfig.getConfig().set("invited."+userid.toString(), null);
+		userConfig.getConfig().set("members."+userid.toString(), null);
 		userConfig.saveConfig();
-		if (getServer().getOfflinePlayer(username).isOnline() && (!getConfig().getBoolean("open-when-op-online") || !isOpOnline())) {
-			getServer().getPlayerExact(username).kickPlayer("You are no longer a member!");
+		if (getServer().getOfflinePlayer(userid).isOnline() && (!getConfig().getBoolean("open-when-op-online") || !isOpOnline())) {
+			getServer().getPlayer(userid).kickPlayer("You are no longer a member!");
 		}
-		getServer().broadcastMessage(ChatColor.YELLOW + username + " is no longer a member. You may re-invite them.");
+		getServer().broadcastMessage(ChatColor.YELLOW + getServer().getOfflinePlayer(userid).getName() + " is no longer a member. You may re-invite them.");
 	}
 	
-	private void voteApprove(String username, String voterName) {
-		List<String> approveVotes = userConfig.getConfig().getStringList("invited."+username.toLowerCase()+".approve-votes");
-		if (!approveVotes.contains(voterName.toLowerCase())) approveVotes.add(voterName.toLowerCase());
+	private void voteApprove(UUID userid, UUID voterid) {
+		List<String> approveVotes = userConfig.getConfig().getStringList("invited."+userid.toString()+".approve-votes");
+		if (!approveVotes.contains(voterid.toString())) approveVotes.add(voterid.toString());
 		int votesReceived = approveVotes.size();
 		int votesNeeded = getConfig().getInt("approve-votes-needed", 0);
 		if (votesReceived >= votesNeeded) {
 			getServer().broadcastMessage(ChatColor.YELLOW + "The tribe has spoken!");
-			promoteToMember(username);
+			promoteToMember(userid);
 		} else {
-			getServer().broadcastMessage(ChatColor.YELLOW + voterName + " voted to make " + username
+			getServer().broadcastMessage(ChatColor.YELLOW + getServer().getPlayer(voterid).getName()+ " voted to make " + getServer().getOfflinePlayer(userid).getName()
 					+ " a member. " + (votesNeeded - votesReceived) + " more votes needed.");
 		}
-		userConfig.getConfig().set("invited."+username.toLowerCase()+".approve-votes", approveVotes);
+		userConfig.getConfig().set("invited."+userid.toString()+".approve-votes", approveVotes);
 		userConfig.saveConfig();
 	}
 	
-	private void voteBan(String username, String voterName) {
-		List<String> banVotes = userConfig.getConfig().getStringList("invited."+username.toLowerCase()+".ban-votes");
-		if (!banVotes.contains(voterName)) banVotes.add(voterName);
+	@SuppressWarnings("deprecation")
+	private void voteBan(UUID userid, UUID voterid) {
+		List<String> banVotes = userConfig.getConfig().getStringList("invited."+userid.toString()+".ban-votes");
+		if (!banVotes.contains(voterid.toString())) banVotes.add(voterid.toString());
 		int votesReceived = banVotes.size();
 		int votesNeeded = getConfig().getInt("ban-votes-needed", 0);
+		OfflinePlayer player = getServer().getOfflinePlayer(userid);
 		if (votesReceived >= votesNeeded) {
-			OfflinePlayer player = getServer().getOfflinePlayer(username);
-			player.setBanned(true);
-			if (player.isOnline()) getServer().getPlayerExact(username).kickPlayer("You have been banned!");
+			player.setBanned(true); //TODO: Change to non-deprecated BanList.addBan method when it uses UUIDs instead of usernames...
+			if (player.isOnline()) getServer().getPlayer(userid).kickPlayer("You have been banned!");
 			getServer().broadcastMessage(ChatColor.YELLOW + "The tribe has spoken!");
-			getServer().broadcastMessage(ChatColor.YELLOW + username + " has been banned and cannot be re-invited.");;
+			getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " has been banned and cannot be re-invited.");;
 		} else {
-			getServer().broadcastMessage(ChatColor.YELLOW + voterName + " voted to ban " + username
+			getServer().broadcastMessage(ChatColor.YELLOW + getServer().getPlayer(voterid).getName() + " voted to ban " + player.getName()
 					+ ". " + (votesNeeded - votesReceived) + " more votes needed.");
 		}
-		userConfig.getConfig().set("invited."+username.toLowerCase()+".ban-votes", banVotes);
+		userConfig.getConfig().set("invited."+userid.toString()+".ban-votes", banVotes);
 		userConfig.saveConfig();
 	}
 }

--- a/src/com/github/deltawhy/invitationonly/InvitationOnly.java
+++ b/src/com/github/deltawhy/invitationonly/InvitationOnly.java
@@ -18,8 +18,11 @@ public class InvitationOnly extends JavaPlugin {
 	public boolean onCommand(CommandSender sender, Command command,
 			String label, String[] args) {
 		Player player = ((sender instanceof Player) ? (Player)sender : null);
+		
+		//Set sender's uuid to "null" if it is the console sending the command to convert it to "an admin" later, if not get the player's uuid
 		UUID senderid = (player == null ? UUID.fromString("00000000-0000-0000-0000-000000000000") : player.getUniqueId());
 		
+		//Innvite command handling
 		if (command.getName().equalsIgnoreCase("invite")) {
 			if (args.length != 1) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
@@ -48,6 +51,8 @@ public class InvitationOnly extends JavaPlugin {
 			}
 			invite(userid, senderid);
 			return true;
+			
+		//Uninvite command handling
 		} else if (command.getName().equalsIgnoreCase("uninvite")) {
 			if (args.length != 1) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
@@ -64,6 +69,8 @@ public class InvitationOnly extends JavaPlugin {
 			}
 			uninvite(userid);
 			return true;
+			
+		//Invite quota command handling	
 		} else if (command.getName().equalsIgnoreCase("invitequota")) {
 			if (player == null && args.length == 0) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
@@ -85,11 +92,15 @@ public class InvitationOnly extends JavaPlugin {
 				}
 			}
 			return true;
+
+		//Approve invite command handling	
 		} else if (command.getName().equalsIgnoreCase("approveinvite")) {
 			if (args.length != 1) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
 			promoteToMember(userid);
 			return true;
+
+		//Unapprove command handling		
 		} else if (command.getName().equalsIgnoreCase("unapprove")) {
 			if (args.length != 1) return false;
 			UUID userid = getOfflinePlayerUUID(args[0]);
@@ -99,6 +110,8 @@ public class InvitationOnly extends JavaPlugin {
 			}
 			removeFromMembers(userid);
 			return true;
+			
+		//Voteapprove command handling			
 		} else if (command.getName().equalsIgnoreCase("voteapprove")) {
 			if (player == null) {
 				sender.sendMessage("This command can not be used from the console.");
@@ -121,6 +134,8 @@ public class InvitationOnly extends JavaPlugin {
 			}
 			voteApprove(userid, senderid);
 			return true;
+			
+		//Voteban command handling
 		} else if (command.getName().equalsIgnoreCase("voteban")) {
 			if (player == null) {
 				sender.sendMessage("This command can not be used from the console.");
@@ -150,13 +165,15 @@ public class InvitationOnly extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		saveDefaultConfig();
+		saveDefaultConfig();		
 		userConfig = new ConfigAccessor(this, "users.yml");
+		
 		userConfig.reloadConfig();
 		playerListener = new PlayerListener(this);
 		getServer().getPluginManager().registerEvents(playerListener, this);
 	}
 	
+	//Function to get the uuid of an offline player by name... rare use is suggest by bukkit staff!
 	@SuppressWarnings("deprecation")
 	public UUID getOfflinePlayerUUID(String username) {
 		return getServer().getOfflinePlayer(username).getUniqueId();
@@ -239,7 +256,7 @@ public class InvitationOnly extends JavaPlugin {
 		userConfig.saveConfig();
 	}
 	
-	@SuppressWarnings("deprecation")
+	@SuppressWarnings("deprecation") //Because of setBanned(), look TODO below
 	private void voteBan(UUID userid, UUID voterid) {
 		List<String> banVotes = userConfig.getConfig().getStringList("invited."+userid.toString()+".ban-votes");
 		if (!banVotes.contains(voterid.toString())) banVotes.add(voterid.toString());

--- a/src/com/github/deltawhy/invitationonly/PlayerListener.java
+++ b/src/com/github/deltawhy/invitationonly/PlayerListener.java
@@ -2,6 +2,7 @@ package com.github.deltawhy.invitationonly;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.*;
@@ -38,5 +39,17 @@ public class PlayerListener implements Listener {
 			e.setKickMessage(ChatColor.RED + "You must be invited to join this server!");
 			if (plugin.getConfig().getBoolean("broadcast-failed-logins", true)) plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but hasn't been invited.");
 		}
+	}
+	
+	//Event for kicking players if there are no OPs/members online anymore!
+	@EventHandler
+	public void onPlayerDisconnect(PlayerQuitEvent e){
+		//1 Tick wait because the PlayerQuitEvent gets invoked before the player actually has left the server!
+		Bukkit.getScheduler().scheduleSyncDelayedTask(this.plugin, new Runnable() {
+			@Override
+			public void run() {
+				plugin.checkPlayers();
+			}
+		}, 1L);	
 	}
 }

--- a/src/com/github/deltawhy/invitationonly/PlayerListener.java
+++ b/src/com/github/deltawhy/invitationonly/PlayerListener.java
@@ -1,5 +1,7 @@
 package com.github.deltawhy.invitationonly;
 
+import java.util.UUID;
+
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.*;
@@ -16,9 +18,10 @@ public class PlayerListener implements Listener {
 	public void onPlayerLogin(PlayerLoginEvent e) {
 		if (e.getResult() != PlayerLoginEvent.Result.ALLOWED) return;
 		Player player = e.getPlayer();
-		if (player.isOp()) return;
-		if (plugin.isMember(player.getUniqueId())) return;
-		if (plugin.isInvited(player.getUniqueId())) {
+		UUID userid = player.getUniqueId();
+		plugin.updateConfigName(userid, player.getName());
+		if (player.isOp() || plugin.isMember(userid)) return;
+		if (plugin.isInvited(userid)) {
 			if (plugin.getConfig().getBoolean("require-op-online", false) && !plugin.isOpOnline()) {
 				e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
 				e.setKickMessage(ChatColor.YELLOW + "You can't join this server unless an op is online!");

--- a/src/com/github/deltawhy/invitationonly/PlayerListener.java
+++ b/src/com/github/deltawhy/invitationonly/PlayerListener.java
@@ -17,11 +17,12 @@ public class PlayerListener implements Listener {
 		if (e.getResult() != PlayerLoginEvent.Result.ALLOWED) return;
 		Player player = e.getPlayer();
 		if (player.isOp()) return;
-		if (plugin.isMember(player.getName())) return;
-		if (plugin.isInvited(player.getName())) {
+		if (plugin.isMember(player.getUniqueId())) return;
+		if (plugin.isInvited(player.getUniqueId())) {
 			if (plugin.getConfig().getBoolean("require-op-online", false) && !plugin.isOpOnline()) {
 				e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
 				e.setKickMessage("You can't join this server unless an op is online!");
+				if (plugin.getConfig().getBoolean("broadcast-failed-logins", true)) plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but there is no OP online.");
 			} else if (plugin.getConfig().getBoolean("require-member-online", false) && !plugin.isMemberOnline()) {
 				e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
 				e.setKickMessage("You can't join this server unless a member is online!");
@@ -32,7 +33,7 @@ public class PlayerListener implements Listener {
 			//Not a member, not invited...
 			e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
 			e.setKickMessage("You must be invited to join this server!");
-			plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but hasn't been invited.");
+			if (plugin.getConfig().getBoolean("broadcast-failed-logins", true)) plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but hasn't been invited.");
 		}
 	}
 }

--- a/src/com/github/deltawhy/invitationonly/PlayerListener.java
+++ b/src/com/github/deltawhy/invitationonly/PlayerListener.java
@@ -21,18 +21,18 @@ public class PlayerListener implements Listener {
 		if (plugin.isInvited(player.getUniqueId())) {
 			if (plugin.getConfig().getBoolean("require-op-online", false) && !plugin.isOpOnline()) {
 				e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
-				e.setKickMessage("You can't join this server unless an op is online!");
+				e.setKickMessage(ChatColor.YELLOW + "You can't join this server unless an op is online!");
 				if (plugin.getConfig().getBoolean("broadcast-failed-logins", true)) plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but there is no OP online.");
 			} else if (plugin.getConfig().getBoolean("require-member-online", false) && !plugin.isMemberOnline()) {
 				e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
-				e.setKickMessage("You can't join this server unless a member is online!");
+				e.setKickMessage(ChatColor.YELLOW + "You can't join this server unless a member is online!");
 			}
 		} else if (plugin.getConfig().getBoolean("open-when-op-online", false) && plugin.isOpOnline()) {
 			//allow access!
 		} else {
 			//Not a member, not invited...
 			e.setResult(PlayerLoginEvent.Result.KICK_WHITELIST);
-			e.setKickMessage("You must be invited to join this server!");
+			e.setKickMessage(ChatColor.RED + "You must be invited to join this server!");
 			if (plugin.getConfig().getBoolean("broadcast-failed-logins", true)) plugin.getServer().broadcastMessage(ChatColor.YELLOW + player.getName() + " tried to join but hasn't been invited.");
 		}
 	}


### PR DESCRIPTION
I updated it to use UUIDs instead of playernames. There is no converter (yet) for old configs.

Added the automatic import of the whitelist (whitelisted players will set as members) on the first start with the plugin (it checks if the users.yml exists).

I also changed the colors of the disconnect messages from white to yellow/red and added a config option (broadcast-failed-logins) to disable the ingame messages if a player joins who was not invited yet to have an ability to disable spam by noninvited players.
